### PR TITLE
Add badgeType data attribute to iconEl

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -207,6 +207,7 @@ function buildBadge(text: string) {
       } else {
         iconEl.addClass("inline-badge-extra");
         iconEl.setText(badgeType.split("|")[1].trim());
+		iconEl.dataset.badgeType = badgeType.split("|")[1].trim();
         attrType = 'text';
         badgeType = 'text';
       }


### PR DESCRIPTION
This adds a data property on plain-text badges so that they can be styled and targeted via css.

For example, I have a CSS Snippet
```
.inline-badge-extra[data-badge-type] {
        background-color: rgb(var(--blue-color));
        border-top-left-radius: 10px;
        border-bottom-left-radius: 10px;
        padding-left: 1ch;
        padding-right: 1ch;
        color: white;
        &::after {
            content: ''
        }
        & + .inline-badge-title-inner {
            padding-left: 1ch;
            padding-right: 1ch;
            background-color:whitesmoke;
            border-top-right-radius: 10px;
            border-bottom-right-radius: 10px;
            color: rgb(var(--blue-color));
        }
    }
```

So that my badge of `[!!|Attribute: +1 Willpower or Presence]`

Can look like this: 

<img width="460" height="71" alt="Screenshot 2025-12-10 at 7 47 30 PM" src="https://github.com/user-attachments/assets/cafe3a63-75ef-498b-b9b7-c1b6e0af6063" />

But with the data attribute, it is now possible to style specific badges instead of them all being styled the same.

I have another CSS Snippet targeting three specific types of badges to style them yellow instead of blue
```
.inline-badge-extra[data-badge-type="Path"],
    .inline-badge-extra[data-badge-type="Resources"],
    .inline-badge-extra[data-badge-type="Ideal"] {
        background-color: rgb(var(--yellow-color));
        & + .inline-badge-title-inner {
            color: rgb(var(--yellow-color));
        }
    }
```
Now I can have plain-text badges and they can be treated differently
```
- Tracking sheet prompt: `[!!|Path:Agent]`
- Character sheet prompt: `[!!|Attribute:+1 Speed]`
```
<img width="368" height="64" alt="Screenshot 2025-12-10 at 7 49 57 PM" src="https://github.com/user-attachments/assets/6bc92944-e1bf-41bb-8e4e-939a85adfa0f" />
