### PR TITLE
Fix: use logical padding for badge text to fix RTL spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -21,7 +21,7 @@ body {
 .inline-badge .gh-type {
 	display: inline-block;
 	font-size: var(--inline-badge-font-size);
-	padding-right: .5em;
+	padding-inline-end: .5em;
 	padding-top: .15em;
 }
 .inline-badge .inline-badge-extra {
@@ -46,7 +46,7 @@ body {
 	display: inline-block;
 	font-size: var(--inline-badge-font-size);
 	font-weight: inherit;
-	padding-right: 5px;
+	padding-inline-end: 5px;
 	padding-top: 2px;
 }
 .inline-badge[data-inline-badge="info"],


### PR DESCRIPTION
### The problem

In right-to-left languages, the badge text looks off: it sticks to the left edge with no space, while there's too much space on the right between the icon and the first letter.

<img width="553" height="288" alt="before" src="https://github.com/user-attachments/assets/fb4976f7-7a47-48ef-8ab2-aea4d3de6f42" />

### The fix

The CSS used the physical `padding-right` for the badge title, which lands on the wrong side once the layout flips in RTL. I switched it to the logical `padding-inline-end` (same for the GitHub label), which follows the text direction automatically.

**This changes nothing for LTR languages**, so no existing user will notice a thing. It only fixes the RTL case.

<img width="545" height="281" alt="after" src="https://github.com/user-attachments/assets/f60c8eaa-9f7c-4826-9526-a5f16ea21dfa" />

