### PR TITLE
Insert badge command

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, MarkdownPostProcessor, setIcon, editorLivePreviewField } from 'obsidian'
+import { App, Editor, FuzzySuggestModal, FuzzyMatch, Plugin, MarkdownPostProcessor, setIcon, editorLivePreviewField } from 'obsidian'
 import { RangeSetBuilder } from "@codemirror/state"
 import { ViewPlugin, WidgetType, EditorView, ViewUpdate, Decoration, DecorationSet } from '@codemirror/view'
 import { BADGE_TYPES } from './constants';
@@ -11,6 +11,13 @@ export default class BadgesPlugin extends Plugin {
 			buildPostProcessor()
 		);
     this.registerEditorExtension(viewPlugin)
+    this.addCommand({
+      id: 'insert-badge',
+      name: 'Insert badge',
+      editorCallback: (editor: Editor) => {
+        new BadgePickerModal(this.app, editor).open();
+        }
+    });
   }
 }
 
@@ -232,3 +239,47 @@ function buildBadge(text: string): HTMLSpanElement | HTMLAnchorElement {
   }
   return newEl;
 }
+
+// Modal for inserting badges 
+class BadgePickerModal extends FuzzySuggestModal<[string, string, string]> {
+  editor: Editor;
+  
+  renderSuggestion(match: FuzzyMatch<[string, string, string]>, el: HTMLElement): void {
+    el.addClass('badge-picker-suggestion');
+    const iconEl = el.createSpan({ cls: 'badge-picker-icon' });
+    setIcon(iconEl, match.item[2]);
+    const textEl = el.createSpan();
+    super.renderSuggestion(match, textEl);
+  }
+
+  constructor(app: App, editor: Editor) {
+    super(app);
+    this.editor = editor;
+    this.setPlaceholder('Choose a badge type…');
+  }
+
+  getItems(): [string, string, string][] {
+    return BADGE_TYPES;
+  }
+
+  getItemText(item: [string, string, string]): string {
+    return item[0];
+  }
+
+  onChooseItem(item: [string, string, string]): void {
+    const key = item[0];
+    const selected = this.editor.getSelection().replace(/\s*\n\s*/g, ' ').trim(); // minor limitation: the parser treats ':' and '|' as delimiters, so a selection containing those will produce odd results. suggested-todo: strip or escape ':' and '|' 
+    const placeholder = ' '; // this could be changed to 'text' or item[1] as default value 
+    const value = selected || placeholder;
+    const start = this.editor.getCursor('from');
+    this.editor.replaceSelection(`\`[!!${key}:${value}]\``);
+    if (!selected) {
+      const chStart = start.ch + 5 + key.length;
+      this.editor.setSelection(
+        { line: start.line, ch: chStart + placeholder.length + 2 }, // this could be { line: start.line, ch: chStart } to select the placeholder text when inserting a badge instead of placing the cursor after it. 
+        { line: start.line, ch: chStart + placeholder.length + 2 }
+      );
+    }
+  }
+}
+

--- a/styles.css
+++ b/styles.css
@@ -426,3 +426,14 @@ body {
 .badge-link:hover .inline-badge {
 	filter: brightness(1.1);
 }
+
+.badge-picker-suggestion {
+  display: flex;
+  align-items: center;
+  gap: var(--size-2-3);
+}
+.badge-picker-icon {
+  display: flex;
+  align-items: center;
+  color: var(--text-muted);
+}


### PR DESCRIPTION
# Add an "Insert badge" command with a badge type picker

Currently badges have to be manually typed, which means remembering both the `` `[!!key:value]` `` syntax and the key of the badge type you want. 
This adds a command **Badges: Insert badge** which opens a searchable picker of all badge types and inserts the chosen badge at the cursor. 
 
The command also becomes available anywhere commands can be used: e.g. the command palette, assigning a hotkey, and other plugins that trigger commands. 

### Behaviour
- Runs from the command palette (`Insert badge`)
<img width="544" height="174" alt="04-34-32_30-07-26" src="https://github.com/user-attachments/assets/c2a41bff-07f8-4947-a4c0-3bf8dd8eb364" />

- Opens a dropdown listing every badge type with their icons, searchable by key 
<img width="474" height="236" alt="04-35-11_30-07-26" src="https://github.com/user-attachments/assets/81c1a1ce-4a7d-4254-a028-6f684767bf3d" />

- On selection, inserts `` `[!!key: ]` `` at the cursor with a single space as badge value placeholder, or uses selected text as badge value
  - I personally prefer having no text as placeholder, which is why its just a space, so i can quickly insert them around while also having the option to select text as the badge value, 
  - but i added comments in main.ts with easy tweaks to this bit  
<img width="836" height="169" alt="04-44-58_30-07-26" src="https://github.com/user-attachments/assets/a5e88bd9-59f5-46e2-8aa4-c6047cd9b408" />

### Example with [Editing Toolbar](https://github.com/PKM-er/obsidian-editing-toolbar) plugin:
- go to Settings -> Editing Toolbar -> Toolbar Commands:
<img width="812" height="654" alt="05-05-17_30-07-26" src="https://github.com/user-attachments/assets/a180ebf0-f7e9-4507-8c11-a3358be73399" />

- click `+` and search for **Badges: Insert badge**
<img width="755" height="167" alt="05-06-35_30-07-26" src="https://github.com/user-attachments/assets/3ef2f4fc-5237-4d41-9d00-24339463221d" />

- choose a command button icon -> I selected Banknote -> then rearranged its location 
<img width="556" height="273" alt="05-08-02_30-07-26" src="https://github.com/user-attachments/assets/1d247ab0-9003-4f62-8286-85ca3cd3445a" />

- Editing toolbar should show the new command icon
<img width="882" height="469" alt="05-09-05_30-07-26" src="https://github.com/user-attachments/assets/29a9c008-43dd-488d-93a3-363a9b735078" />

#### Demonstration:
<img width="845" height="408" alt="05-11-12_30-07-26" src="https://github.com/user-attachments/assets/438ffb46-0035-4763-97bb-0c4288c20518" />
<img width="841" height="417" alt="05-47-39_30-07-26" src="https://github.com/user-attachments/assets/c3fc3d59-5de9-4656-8406-a6a254c410bc" />



